### PR TITLE
chore(deps): bump wstunnel version from 10.3.0 to 10.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apk add --no-cache \
 ### WSTunnel
 FROM builder AS wstunnel
 
-ARG WSTUNNEL_VERSION="10.3.0"
+ARG WSTUNNEL_VERSION="10.4.0"
 ENV WSTUNNEL_VERSION=$WSTUNNEL_VERSION
 RUN curl -fsSL https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz | \
   tar xvzf - -C /usr/bin wstunnel && \

--- a/melange/wstunnel.yaml
+++ b/melange/wstunnel.yaml
@@ -1,6 +1,6 @@
 package:
   name: wstunnel
-  version: "10.3.0"
+  version: "10.4.0"
   epoch: 0
   description: Wstunnel uses the websocket protocol which is compatible with http in order to bypass firewalls and proxies
   url: https://github.com/erebe/wstunnel
@@ -22,13 +22,13 @@ pipeline:
     uses: fetch
     with:
       uri: https://github.com/erebe/wstunnel/releases/download/v${{package.version}}/wstunnel_${{package.version}}_linux_arm64.tar.gz
-      expected-sha256: 33bc9132937145990ac308fd36af466e6e4d917cbbcc916afa098f8fe335d170
+      expected-sha256: c8e88b696d5415d57ad9b7ec8968d15919cf359e427c0bd1d23a8b33d691b96e
       strip-components: 0
   - if: ${{build.arch}} == 'x86_64'
     uses: fetch
     with:
       uri: https://github.com/erebe/wstunnel/releases/download/v${{package.version}}/wstunnel_${{package.version}}_linux_amd64.tar.gz
-      expected-sha256: cb2ab9c3041715dce5a6901e3b5715a816b010a0056250c6486d4ab66fcc0ee0
+      expected-sha256: daefe5838e6c50abc7342cdf3b94a71d7d87fde146cb61c6c689eb4bcf6d4cb8
       strip-components: 0
   - runs: |
       install -dm755 "${{targets.destdir}}"/usr/bin


### PR DESCRIPTION
Note: for melange configuration, we use the following command to update the version: 

`melange bump melange/wstunnel.yaml 10.4.0`

This way, sha256 sums are automatically updated for all architectures.