### PR TITLE
feat: improve stability defaults for reverse tunnel resilience

### DIFF
--- a/helm/ggbridge/templates/client/deployment.yaml
+++ b/helm/ggbridge/templates/client/deployment.yaml
@@ -131,6 +131,10 @@ spec:
             - name: LOG_LEVEL
               value: {{ . | quote }}
             {{- end }}
+            {{- with $.Values.pingFrequency }}
+            - name: PING_FREQUENCY
+              value: {{ . | quote }}
+            {{- end }}
             - name: PROXY_PROTOCOL_ENABLED
               value: {{ $.Values.proxyProtocol.enabled | quote }}
             - name: TUNNEL_SOCKS_ENABLED
@@ -139,6 +143,10 @@ spec:
               value: {{ $.Values.client.tunnels.tls.enabled | quote }}
             - name: TUNNEL_WEB_ENABLED
               value: {{ $.Values.client.tunnels.web.enabled | quote }}
+            - name: REVERSE_TUNNEL_HEALTH_HANDLERS
+              value: {{ $.Values.client.reverseTunnels.health.handlers | default 1 | quote }}
+            - name: REVERSE_TUNNEL_SOCKS_HANDLERS
+              value: {{ $.Values.client.reverseTunnels.socks.handlers | default 1 | quote }}
             - name: REVERSE_TUNNEL_SOCKS_ENABLED
               value: {{ $.Values.client.reverseTunnels.socks.enabled | quote }}
             - name: REVERSE_TUNNEL_TLS_ENABLED

--- a/helm/ggbridge/templates/server/deployment.yaml
+++ b/helm/ggbridge/templates/server/deployment.yaml
@@ -96,6 +96,10 @@ spec:
               value: {{ $.Values.server.service.ports.ws.containerPort | quote }}
             - name: SERVER_IDLE_TIMEOUT
               value: {{ $.Values.server.idleTimeout | quote }}
+            {{- with $.Values.pingFrequency }}
+            - name: PING_FREQUENCY
+              value: {{ . | quote }}
+            {{- end }}
             {{- if and $.Values.tls.enabled (eq (include "ggbridge.server.trafficRouting.enabled" $) "false") }}
             - name: TLS_ENABLED
               value: "true"

--- a/helm/ggbridge/values.yaml
+++ b/helm/ggbridge/values.yaml
@@ -126,6 +126,12 @@ hostname: ""
 # -- Set log level
 logLevel: INFO
 
+# -- WebSocket ping frequency in seconds (applies to both client and server).
+# wstunnel sends a ping frame at this interval to detect dead connections.
+# After 3 missed pings, the connection is declared dead.
+# Lower values improve detection speed but increase WebSocket frame overhead.
+pingFrequency: 20
+
 # -- Dns resolver to use to lookup ips of domain name
 dnsResolver: ""
 
@@ -279,8 +285,10 @@ networkPolicy:
   ingressNSPodMatchLabels: {}
 
 client:
-  # -- Pool of open connection to the server, in order to speed up the connection process
-  connectionMinIdle: 0
+  # -- Pool of open connection to the server, in order to speed up the connection process.
+  # Keeping at least 1 idle connection pre-establishes the TCP+TLS handshake,
+  # reducing the gap between consecutive reverse tunnel WebSocket handlers.
+  connectionMinIdle: 3
 
   tunnels:
     health:
@@ -300,9 +308,20 @@ client:
     health:
       # -- Enable server to client health tunnel
       enabled: true
+      # -- Number of concurrent WebSocket handlers (run_reverse_tunnel loops) for the health tunnel.
+      # Each handler is an independent loop that pre-opens a WebSocket and waits for a connection.
+      # With handlers=1 (default), there is a brief gap between handlers where the idle timer may fire.
+      # With handlers=2, a second handler is always waiting, preventing the idle timer from closing the listener.
+      # Values > 2 provide diminishing returns for health (1 probe every 7s).
+      handlers: 1
     socks:
       # -- Enable server to client socks tunnel
       enabled: true
+      # -- Number of concurrent WebSocket handlers for the SOCKS tunnel.
+      # Higher values reduce dispatch latency when multiple SOCKS connections arrive simultaneously.
+      # With handlers=1, concurrent requests are dispatched sequentially (one WS creation time per request).
+      # With handlers=N, the first N requests are dispatched instantly.
+      handlers: 1
     tls:
       # -- Enable server to client tls tunnel
       enabled: false
@@ -326,8 +345,11 @@ client:
     failureThreshold: 3
 
 server:
-  # -- Configure how much time a tunnel server is going to wait idle (without any new ws clients) before unbinding itself/stopping the server
-  idleTimeout: 30
+  # -- Configure how much time a tunnel server is going to wait idle (without any new ws clients) before unbinding itself/stopping the server.
+  # A higher value reduces the chance of the reverse tunnel listener closing during
+  # the gap between consecutive WebSocket handlers (the 1:1 WebSocket:connection model
+  # creates a brief gap every ~7s when a health probe is consumed).
+  idleTimeout: 120
 
   service:
     # -- Specify server serivce annottions
@@ -451,10 +473,14 @@ proxy:
 
     # -- Nginx upstream configuration
     upstream:
-      # -- Maximum number of unsuccessful attempts to communicate with the server
-      maxFails: 2
-      # -- Time during which the specified number of unsuccessful attempts must happen to mark the server as unavailable
-      failTimeout: 120s
+      # -- Maximum number of unsuccessful attempts to communicate with the server.
+      # Aligned with the Kubernetes readiness probe failureThreshold (3) to avoid
+      # marking the upstream down too early on transient failures.
+      maxFails: 3
+      # -- Time during which the specified number of unsuccessful attempts must happen to mark the server as unavailable.
+      # After max_fails is reached, nginx stops retrying the upstream for this duration.
+      # A lower value allows faster recovery when the reverse tunnel listener re-opens.
+      failTimeout: 15s
       # -- Enable load balancing for health upstream (when true will set load-balancing upstream for healthcheck)
       healthLoadBalancing: false
       # -- List of server proxy to disable in nginx conf

--- a/main.go
+++ b/main.go
@@ -118,6 +118,14 @@ func buildClientCommand() []string {
 	serverPathPrefix := os.Getenv("SERVER_PATH_PREFIX")
 	pingFrequency := getEnv("PING_FREQUENCY", strconv.Itoa(DefaultPingFrequency))
 	connectionMinIdle := getEnv("CONNECTION_MIN_IDLE", "0")
+	healthHandlers, _ := strconv.Atoi(getEnv("REVERSE_TUNNEL_HEALTH_HANDLERS", "1"))
+	if healthHandlers < 1 {
+		healthHandlers = 1
+	}
+	socksHandlers, _ := strconv.Atoi(getEnv("REVERSE_TUNNEL_SOCKS_HANDLERS", "1"))
+	if socksHandlers < 1 {
+		socksHandlers = 1
+	}
 	dnsResolver := os.Getenv("DNS_RESOLVER")
 	tlsEnabled, err := strconv.ParseBool(getEnv("TLS_ENABLED", "false"))
 	proxyProtocolEnabled, err := strconv.ParseBool(getEnv("PROXY_PROTOCOL_ENABLED", "true"))
@@ -181,9 +189,16 @@ func buildClientCommand() []string {
 		serverUrl,
 		"--websocket-ping-frequency-sec", pingFrequency,
 		"--connection-min-idle", connectionMinIdle,
-		// Healthcheck tunnel
+		// Healthcheck tunnel (local-to-remote)
 		"--local-to-remote", fmt.Sprintf("tcp://0.0.0.0:%s:127.0.0.1:%s", tunnelHealthPort, tunnelHealthRemotePort),
-		"--remote-to-local", fmt.Sprintf("tcp://0.0.0.0:%s:127.0.0.1:%s", tunnelHealthPort, tunnelHealthRemotePort),
+	}
+
+	// Healthcheck reverse tunnel (remote-to-local) with configurable handler count.
+	// Each --remote-to-local flag spawns an independent run_reverse_tunnel loop in wstunnel.
+	// With handlers > 1, multiple handlers wait on the same server listener, keeping
+	// receiver_count high enough to prevent the idle timer from closing the listener.
+	for i := 0; i < healthHandlers; i++ {
+		cmd = append(cmd, "--remote-to-local", fmt.Sprintf("tcp://0.0.0.0:%s:127.0.0.1:%s", tunnelHealthPort, tunnelHealthRemotePort))
 	}
 
 	// Use a specific prefix that will show up in the http path during the upgrade request
@@ -234,9 +249,11 @@ func buildClientCommand() []string {
 		cmd = append(cmd, "--local-to-remote", target)
 	}
 
-	// Enables server to client proxy tunnel
+	// Enables server to client proxy tunnel with configurable handler count.
 	if reverseTunnelSocksEnabled {
-		cmd = append(cmd, "--remote-to-local", fmt.Sprintf("socks5://0.0.0.0:%s", tunnelSocksPort))
+		for i := 0; i < socksHandlers; i++ {
+			cmd = append(cmd, "--remote-to-local", fmt.Sprintf("socks5://0.0.0.0:%s", tunnelSocksPort))
+		}
 	}
 
 	// Enables server to client tcp tunnel


### PR DESCRIPTION
## Summary

Adjust default parameters and add configurable handler count per reverse tunnel type to reduce the frequency and duration of reverse tunnel listener closures during degraded conditions (ingress disruption, Karpenter node consolidation, network saturation).

### Context

Investigation of the March 31st outage (ENT-3771) revealed that the ReverseTcp tunnel health listener (port 9081) closes and re-opens in a loop during degraded conditions. This is caused by the wstunnel 1:1 model (one WebSocket per TCP connection): each health probe cycle creates a brief gap between consecutive WebSocket handlers, and if the idle timer ticks during that gap, the listener closes.

See the [technical reference](https://www.notion.so/gitguardian/336a119c1d9f807982e0d479a6e19821) for a full analysis of the mechanism.

### Changes

| Parameter | Before | After | File(s) | Impact |
|---|---|---|---|---|
| `SERVER_IDLE_TIMEOUT` | 30s | **120s** | `values.yaml` | Listener tolerates longer gaps before closing |
| `CONNECTION_MIN_IDLE` | 0 | **3** | `values.yaml` | 3 pre-established TCP/TLS connections for burst traffic |
| `PING_FREQUENCY` | 30s (hardcoded) | **20s** (configurable) | `values.yaml`, `main.go`, client+server templates | Faster dead tunnel detection, now exposed as Helm value |
| nginx `failTimeout` | 120s | **15s** | `values.yaml` | Proxy retries upstream faster after recovery |
| nginx `maxFails` | 2 | **3** | `values.yaml` | Aligned with K8s readiness failureThreshold |
| `reverseTunnels.health.handlers` | N/A | **1** | `values.yaml`, `main.go`, client template | **New** -- configurable handler count for health tunnel |
| `reverseTunnels.socks.handlers` | N/A | **1** | `values.yaml`, `main.go`, client template | **New** -- configurable handler count for SOCKS tunnel |

### Configurable handler count (new feature)

Each `--remote-to-local` flag in wstunnel spawns one `run_reverse_tunnel` loop -- an infinite cycle that opens a WebSocket, waits for a connection, forwards it, then opens the next WebSocket. With 1 handler (default), connections are dispatched sequentially: each new request must wait for the loop to open a new WebSocket before being served.

Setting `handlers: N` repeats the `--remote-to-local` flag N times, spawning N independent loops on the same listener. Incoming connections are queued in a `bounded(10)` channel and dispatched to whichever handler calls `recv()` first.

With N handlers:
- **N simultaneous requests are dispatched instantly** (one per waiting handler), without waiting for a new WebSocket to be created
- Remaining requests are served sequentially as handlers cycle back, but with N loops working in parallel the dispatch throughput is multiplied by N
- The server-side `receiver_count` stays >= N, which reduces the risk of the idle timer closing the listener during handler replacement gaps

The handler count is configurable **independently** per tunnel type:

```yaml
client:
  reverseTunnels:
    health:
      enabled: true
      handlers: 2   # reduces dispatch latency for concurrent probes
    socks:
      enabled: true
      handlers: 3   # improves latency for concurrent SOCKS requests (e.g. browser traffic)
```

Env vars: `REVERSE_TUNNEL_HEALTH_HANDLERS` (default: 1), `REVERSE_TUNNEL_SOCKS_HANDLERS` (default: 1). Minimum value is 1 (clamped in code).

**Default is 1** (no behavior change from current single-handler model).

### Why these values

**`SERVER_IDLE_TIMEOUT=120`**: safety net -- with handlers >= 2, the timer should never trigger. If all handlers die simultaneously, 120s gives time for reconnection.

**`CONNECTION_MIN_IDLE=3`**: the pool pre-establishes 3 TCP+TLS connections. This covers burst traffic from concurrent SOCKS connections (git operations, scans) where multiple WebSockets are opened simultaneously. With `min_idle=1`, only the first request is served instantly; with `min_idle=3`, the first 3 are. Each idle connection is recycled every 30s (`max_lifetime`) to stay fresh. Cost: 3 idle TCP sockets + ~6 TLS handshakes/min in background.

**`PING_FREQUENCY=20`**: 3 missed pings at 20s = 60s dead detection. Now configurable via Helm.

**`failTimeout=15s`**: proxy detects upstream recovery within ~2 probe cycles instead of 2 minutes.

**`maxFails=3`**: aligned with Kubernetes readiness probe `failureThreshold` (3).

### Ref

- [ENT-3778](https://linear.app/gitguardian/issue/ENT-3778)
- [ENT-3771](https://linear.app/gitguardian/issue/ENT-3771) (incident investigation)