### PR TITLE
fix(probes): remove grace-period to prevent probe on-off flackiness

### DIFF
--- a/helm/ggbridge/values.yaml
+++ b/helm/ggbridge/values.yaml
@@ -336,7 +336,6 @@ client:
       command:
         - ggbridge
         - healthcheck
-        - -grace-period=60
         - http://127.0.0.1:9081/healthz
     initialDelaySeconds: 10
     periodSeconds: 7
@@ -749,7 +748,6 @@ proxy:
         - ggbridge
         - healthcheck
         - -pid-file=/var/run/nginx.pid
-        - -grace-period=60
         - http://127.0.0.1:9081/healthz
     initialDelaySeconds: 10
     periodSeconds: 7


### PR DESCRIPTION
the healthcheck code:
 
```
if gracePeriod > 0 && pidFile != "" {
    fileInfo, err := os.Stat(pidFile)
    ...
    elapsedTime := time.Since(startTime).Seconds()
    if int(elapsedTime) < gracePeriod {
        log.Print("Within grace period, skipping healthcheck errors")
        os.Exit(0)   // ← return SUCCESS without testing /healthz
    }
}
```

always return true during gracePeriod, this is a false signal, as returning true means the pod will be ready and serve traffic, while it should not.

This means we have:
during initialDelaysSeconds: pod is always not-ready as expected.
then we have the grace period: the pod is falsy ready due to the skip
we go back to actual probing: status is correct

