### PR TITLE
chore(helm): lower resource requests based on actual usage

### DIFF
--- a/helm/ggbridge/values.yaml
+++ b/helm/ggbridge/values.yaml
@@ -97,8 +97,8 @@ extraEnv: []
 resources:
   # -- Set container requests
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 10m
+    memory: 32Mi
   # -- Set container limits
   limits: {}
 
@@ -781,7 +781,7 @@ proxy:
   resources:
     # -- Set proxy container requests
     requests:
-      cpu: 50m
-      memory: 64Mi
+      cpu: 10m
+      memory: 16Mi
     # -- Set proxy container limits
     limits: {}


### PR DESCRIPTION
## Summary
Reduce default Helm resource requests for the main and proxy containers to better match observed usage.

## Changes
- `resources.requests`: cpu `100m → 10m`, memory `128Mi → 32Mi`
- `proxy.resources.requests`: cpu `50m → 10m`, memory `64Mi → 16Mi`

## Test plan
- [ ] Verify pods still schedule and run within new requests under typical load
- [ ] Confirm no regressions in tunnel stability after rollout