### PR TITLE
chore(helm): lower resource requests based on actual usage

### DIFF
--- a/helm/ggbridge/values.yaml
+++ b/helm/ggbridge/values.yaml
@@ -97,8 +97,8 @@ extraEnv: []
 resources:
   # -- Set container requests
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 10m
+    memory: 32Mi
   # -- Set container limits
   limits: {}
 
@@ -781,7 +781,7 @@ proxy:
   resources:
     # -- Set proxy container requests
     requests:
-      cpu: 50m
-      memory: 64Mi
+      cpu: 10m
+      memory: 16Mi
     # -- Set proxy container limits
     limits: {}


### PR DESCRIPTION
## Summary

- Lower default CPU request for the main container: `100m` → `10m`
- Lower default memory request for the main container: `128Mi` → `32Mi`
- Lower default CPU request for the proxy container: `50m` → `10m`
- Lower default memory request for the proxy container: `64Mi` → `16Mi`

## Why

The previous defaults were significantly higher than actual observed usage, causing unnecessary resource reservation on clusters. The new values are aligned with real-world consumption while still allowing the containers to burst via uncapped limits.

## Reviewer notes

Only `values.yaml` defaults are changed — no logic, no templates. Deployments with custom resource overrides are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)