### PR TITLE
fix(helm): always mount ca.crt for the server on the direct-TLS path

### DIFF
--- a/helm/ggbridge/templates/server/deployment.yaml
+++ b/helm/ggbridge/templates/server/deployment.yaml
@@ -224,10 +224,8 @@ spec:
             {{- if $.Values.tls.existingSecret }}
             secretName: {{ $.Values.tls.existingSecret }}
             items:
-              {{- with $.Values.tls.existingSecretKeys.caCrt }}
-              - key: {{ . }}
+              - key: {{ default "ca.crt" $.Values.tls.existingSecretKeys.caCrt }}
                 path: ca.crt
-              {{- end }}
               - key: {{ default "tls.crt" $.Values.tls.existingSecretKeys.crt }}
                 path: server.crt
               - key: {{ default "tls.key" $.Values.tls.existingSecretKeys.key }}


### PR DESCRIPTION
a latent bug on the direct-TLS server path. **Low priority: no current users** (see below), but the present default guarantees a crash loop, so it should not stay.

## The bug

`server/deployment.yaml` wrapped the `ca.crt` volume item in a `with` guard on `tls.existingSecretKeys.caCrt`, which defaults to `""`. So a server using `tls.existingSecret` with default key names mounted **no `ca.crt` at all** — while the container still got `TLS_ENABLED` and therefore started wstunnel with `--tls-client-ca-certs /etc/ggbridge/tls/ca.crt`.

wstunnel panics on the missing file:

```
Cannot load client CA certificate (mTLS): No such file or directory
```

The pod crash-loops with nothing in the chart explaining why. The client role already gets this right (`default "ca.crt"`); this makes the server match.

## Why mandatory, not `optional: true`

The binary passes `--tls-client-ca-certs` whenever TLS is enabled, with no notion of `tls.mode` — nothing in the chart sets a `TLS_MODE` env var. wstunnel documents that flag as *"Enables mTLS (client authentication with certificate)"*.

Two consequences, both verified against wstunnel 10.4.3:

- the CA is genuinely required on this path, so defaulting the key name is the right fix
- a direct-TLS server is **always mutual**, and `tls.mode: simple` is silently ignored there rather than honoured (it works correctly on the L7 paths, which are its only consumers). Rejecting that combination is tracked in [ENT-4205](https://linear.app/gitguardian/issue/ENT-4205) rather than plumbing the mode through.

## Scope — who is affected

Nobody currently, which is why this is Low

## Verification

Before/after `helm template` matrix over six configurations. The **only** change is the added `ca.crt` item on the direct-TLS renders:

| config | result |
|---|---|
| direct TLS, default keys | `ca.crt` item added ✅ |
| direct TLS, `tls.mode: simple` | `ca.crt` item added ✅ |
| direct TLS, custom key names | byte-identical |
| direct TLS, generated certs | byte-identical |
| Ingress (L7) | byte-identical |
| client | byte-identical |

`helm lint --strict helm/ggbridge` passes. Note this chart has no template unit-test framework or snapshots — `mise run test` exercises the Go binary via dagger — so verification is the render diff. Introducing helm-unittest is noted on ENT-4205, which adds validation logic that needs it.