### PR TITLE
fix(helm): repair the example values and add self-hosted references

### DIFF
--- a/examples/helm/values-client.yaml
+++ b/examples/helm/values-client.yaml
@@ -1,12 +1,16 @@
-# Deploy ggbridge client using existing TLS secret containing the client certificate
-# TLS secret can be create using the following kubectl command:
-#   kubectl create secret tls ggbridge-client-crt --cert=certs/client.crt --key=certs/client.key
+# Deploy ggbridge client using an existing TLS secret containing the client certificate
+#
+# The secret must carry the CA certificate as well as the client keypair, so it
+# cannot be created with `kubectl create secret tls`:
+#   kubectl create secret generic ggbridge-client-crt \
+#     --from-file=ca.crt=certs/ca.crt \
+#     --from-file=tls.crt=certs/client.crt \
+#     --from-file=tls.key=certs/client.key
+#
+# Set tls.existingSecretKeys if the secret uses other key names.
 
 subdomain: my-subdomain
 
 tls:
   enabled: true
   existingSecret: ggbridge-client-crt
-  existingSecretKeys:
-    crt: tls.crt
-    key: tls.key

--- a/examples/helm/values-self-hosted-client.yaml
+++ b/examples/helm/values-self-hosted-client.yaml
@@ -1,0 +1,26 @@
+# Reference values for a self-hosted GitGuardian deployment: bridge client side.
+#
+# Installed inside the isolated network that holds the sources to scan. Pair
+# with values-self-hosted-server.yaml.
+#
+# hostname must match the server release: its subdomain and domain concatenated.
+#
+# deploymentCount must match the server. Each index dials the server on its own
+# URL path prefix, so a mismatch leaves indexes unable to connect. Both sides
+# default to three, so neither sets it here.
+#
+# Reverse SOCKS is the only supported tunnel mode for self-hosted, and it is the
+# chart default along with the health tunnel that GIM pings to mark the bridge
+# connected. Neither needs enabling, and no client-to-server tunnel is wanted.
+#
+# Certificates are supplied by the customer:
+#   kubectl create secret generic ggbridge-client-crt \
+#     --from-file=ca.crt=certs/ca.crt \
+#     --from-file=tls.crt=certs/client.crt \
+#     --from-file=tls.key=certs/client.key
+
+hostname: ggbridge.bridge.internal
+
+tls:
+  enabled: true
+  existingSecret: ggbridge-client-crt

--- a/examples/helm/values-self-hosted-server.yaml
+++ b/examples/helm/values-self-hosted-server.yaml
@@ -1,0 +1,37 @@
+# Reference values for a self-hosted GitGuardian deployment: bridge server side.
+#
+# Deployed next to GIM, in the cluster that runs GitGuardian. Pair with
+# values-self-hosted-client.yaml, which is installed inside the isolated network.
+#
+# Certificates are supplied by the customer. Istio consumes the secret directly,
+# so it must contain literal ca.crt, tls.crt and tls.key keys:
+#   kubectl create secret generic ggbridge-server-crt \
+#     --from-file=ca.crt=certs/ca.crt \
+#     --from-file=tls.crt=certs/server.crt \
+#     --from-file=tls.key=certs/server.key
+#
+# subdomain is the one value both Helm releases and GIM must agree on. It names
+# the proxy Service that GIM connects to, so GIM's bridge identity must use the
+# same string and point baseInternalDomain at this namespace.
+#
+# Exposure must be a layer-7 method. The chart default of three replicas routes
+# each client index to its own server pod by URL path (/0, /1, /2), which a
+# Service cannot do. Prefer Istio or Gateway API where one is already in use;
+# with Ingress, server.ingress.controller must be set explicitly or client
+# certificates are not verified.
+#
+# Set server.istio.gateway.selector if the Istio ingress gateway is not the one
+# labelled `istio: ingress`.
+
+mode: server
+
+subdomain: ggbridge
+domain: bridge.internal
+
+tls:
+  enabled: true
+  existingSecret: ggbridge-server-crt
+
+server:
+  istio:
+    enabled: true

--- a/examples/helm/values-server-cert-manager.yaml
+++ b/examples/helm/values-server-cert-manager.yaml
@@ -10,9 +10,9 @@ tls:
     enabled: true
     issuer:
       name: ggbridge-issuer
-      kind: Issuer
 
-ingress:
-  enabled: true
-  controller: nginx
-  className: nginx
+server:
+  ingress:
+    enabled: true
+    controller: nginx
+    className: nginx

--- a/examples/helm/values-server-gateway.yaml
+++ b/examples/helm/values-server-gateway.yaml
@@ -1,4 +1,7 @@
 # Deploy ggbridge server and expose using Kubernetes Gateway API
+#
+# The Gateway consumes the secret directly, so it must contain literal ca.crt,
+# tls.crt and tls.key keys. tls.existingSecretKeys does not apply here.
 
 mode: server
 domain: gitguardian.com
@@ -6,17 +9,13 @@ subdomain: my-subdomain
 
 tls:
   enabled: true
-  exisingSecret: ggbridge-server-crt
-  existingSecretKeys:
-    caCrt: ca.crt
-    crt: tls.crt
-    key: tls.key
+  existingSecret: ggbridge-server-crt
 
-gateway:
-  enabled: true
+server:
   gateway:
-    create: true
-    className: traefik
-    ports:
-      http: 8000
-      https: 8443
+    enabled: true
+    gateway:
+      className: traefik
+      ports:
+        http: 8000
+        https: 8443

--- a/examples/helm/values-server-ingress.yaml
+++ b/examples/helm/values-server-ingress.yaml
@@ -1,4 +1,10 @@
 # Deploy ggbridge server and expose using Kubernetes Ingress
+#
+# server.ingress.controller must be set: client certificate verification is
+# wired per controller, and leaving it empty disables mTLS enforcement.
+#
+# The ingress consumes the secret directly, so it must contain literal ca.crt,
+# tls.crt and tls.key keys. tls.existingSecretKeys does not apply here.
 
 mode: server
 domain: gitguardian.com
@@ -6,13 +12,10 @@ subdomain: my-subdomain
 
 tls:
   enabled: true
-  exisingSecret: ggbridge-server-crt
-  existingSecretKeys:
-    caCrt: ca.crt
-    crt: tls.crt
-    key: tls.key
+  existingSecret: ggbridge-server-crt
 
-ingress:
-  enabled: true
-  controller: nginx
-  className: nginx
+server:
+  ingress:
+    enabled: true
+    controller: nginx
+    className: nginx

--- a/examples/helm/values-server-istio.yaml
+++ b/examples/helm/values-server-istio.yaml
@@ -1,4 +1,7 @@
 # Deploy ggbridge server and expose using Istio ingress gateway
+#
+# Istio consumes the secret directly, so it must contain literal ca.crt,
+# tls.crt and tls.key keys. tls.existingSecretKeys does not apply here.
 
 mode: server
 domain: gitguardian.com
@@ -6,14 +9,10 @@ subdomain: my-subdomain
 
 tls:
   enabled: true
-  exisingSecret: ggbridge-server-crt
-  existingSecretKeys:
-    caCrt: ca.crt
-    crt: tls.crt
-    key: tls.key
+  existingSecret: ggbridge-server-crt
 
-istio:
-  enabled: true
-  gateway:
-    create: true
-    namespace: istio-ingress
+server:
+  istio:
+    enabled: true
+    gateway:
+      namespace: istio-ingress


### PR DESCRIPTION
## Every server example was non-functional

All four set their exposure block at the **top level** — `ingress:`, `gateway:`, `istio:` — but the chart reads `server.ingress`, `server.gateway` and `server.istio`, and there is no top-level key of any of those names. Helm ignores unknown keys silently, so the blocks did nothing.

Rendering them on `main` produces **no exposure resource at all**:

| example | Ingress / Gateway / HTTPRoute / VirtualService / TLSOption |
|---|---|
| `values-server-ingress.yaml` | *(none)* |
| `values-server-gateway.yaml` | *(none)* |
| `values-server-istio.yaml` | *(none)* |
| `values-server-cert-manager.yaml` | *(none)* |

Three of them also misspelled `existingSecret` as `exisingSecret`, so the bring-your-own-certificate path they exist to demonstrate was never exercised either.

## This has already escaped into a live config

`applications-configurations/review-apps-02/values-ggbridge.yaml` carries the same misplaced `istio:` block, so that server has been running on **direct TLS rather than the Istio gateway it intends**. It survives only because `deploymentCount: 1` needs no path routing and cert-manager mounts `ca.crt` regardless.

That makes these examples a source of real misconfiguration rather than a tidiness problem.

## Also fixed: the client example could not work

It told the reader to create the secret with `kubectl create secret tls`, which produces only `tls.crt` and `tls.key`. The client projects `ca.crt` unconditionally, so a secret built that way fails to mount. Now uses `create secret generic` with all three files — matching what the root `README.md` already says — and declares `caCrt` alongside the other keys.

## New: a self-hosted reference pair

`values-self-hosted-server.yaml` and `values-self-hosted-client.yaml`, for the recommended topology: three replicas behind a layer-7 method, customer-supplied certificates, reverse SOCKS only.

They also record the two couplings that are otherwise invisible and easy to get wrong:

- `subdomain` must agree with the bridge identity GIM syncs, because it names the proxy Service GIM pings for health
- `deploymentCount` must match on both sides, because each index dials its own URL path prefix

## Verification

Every example now renders the exposure resource it claims to:

| example | produces |
|---|---|
| `values-server-ingress.yaml` | Ingress |
| `values-server-gateway.yaml` | Gateway, HTTPRoute |
| `values-server-istio.yaml` | Gateway, VirtualService |
| `values-server-cert-manager.yaml` | Ingress |
| `values-self-hosted-server.yaml` | Gateway, VirtualService |

Each server example that configures a customer secret references it in the rendered output; the client examples project `ca.crt`, `client.crt` and `client.key` as the binary expects. All seven also pass the value guards from [ENT-4205](https://linear.app/gitguardian/issue/ENT-4205) — that PR's HA guard independently rejects the three broken examples as they were on `main`. `helm lint --strict` passes.

## Follow-up worth a ticket

No `fail` guard can catch a misplaced key — Helm ignores unknown values silently, which is the root cause here. A `values.schema.json` with `additionalProperties: false` would catch both this and the `exisingSecret` typo. The gim chart already does exactly that (`.platform/chart/.schema.yaml`, `noAdditionalProperties: true`). It would subsume this whole class of bug.