### PR TITLE
chore(mise): bump helm to 4.2.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,6 +154,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: azure/setup-helm@v5.0.0
+        with:
+          version: v4.2.3
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,6 +178,8 @@ jobs:
     if: ${{ github.event_name != 'schedule' }}
     steps:
       - uses: azure/setup-helm@v5.0.0
+        with:
+          version: v4.2.3
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/unstable.yaml
+++ b/.github/workflows/unstable.yaml
@@ -189,6 +189,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: azure/setup-helm@v5.0.0
+        with:
+          version: v4.2.3
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 "aqua:dagger/dagger" = { version = "0.18.11" }
-"aqua:helm" = { version = "3.18.3"}
+"aqua:helm" = { version = "4.2.3"}
 "aqua:norwoodj/helm-docs" = { version = "1.14.2"}
 "pipx:ggshield" = { version = "1.41.0", uvx_args = "--python-preference=system" }
 "pipx:pre-commit" = { version = "4.2.0", uvx_args = "--python-preference=system" }


### PR DESCRIPTION
The pin was still on 3.18.3 while CI and local shells had already moved to Helm 4: azure/setup-helm installs the latest release, and the pin was shadowed locally by a system install. A stale pin that nobody resolves to is worse than no pin, because it hides the drift rather than preventing it.

Helm 4 is not a transparent upgrade -- it verifies plugin provenance by default, which is what broke installing helm-unittest in CI -- so the bump is worth making deliberate rather than leaving the two environments to diverge further.

Rendering is unaffected. The SaaS production values were templated under both 3.18.3 and 4.2.3 and parse to identical objects, 29 documents either way; the only textual difference is trailing whitespace. All 49 values files in applications-configurations render under 4.2.3, and helm lint --strict passes.